### PR TITLE
Add LibreOffice table population script

### DIFF
--- a/libreoffice_table_fill.py
+++ b/libreoffice_table_fill.py
@@ -1,0 +1,198 @@
+"""Populate a Writer table with rows extracted from a Calc workbook via LibreOffice.
+
+This script uses a UNO connection to LibreOffice to open a hard-coded XLSX file,
+transform selected rows, and write formatted text into the first table of a
+hard-coded Writer document. LibreOffice must be running in listening mode, for
+example:
+
+    soffice --headless --accept="socket,host=localhost,port=2002;urp;"
+
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+import uno
+import unohelper
+from com.sun.star.beans import PropertyValue
+from com.sun.star.text import XTextTable
+
+# Hard-coded paths to the source spreadsheet and target document
+CALC_PATH = Path("data/source.xlsx")
+DOC_PATH = Path("data/target.doc")
+
+
+@dataclass
+class AddressEntry:
+    """Normalized address data from a Calc row."""
+
+    family_name: str
+    family_info: str
+    address_line_1: str
+    address_apt_line: str
+    address_final_line: str
+
+    @property
+    def formatted_text(self) -> str:
+        lines: List[str] = []
+        header = f"{self.family_info} {self.family_name}".strip()
+        if header:
+            lines.append(header)
+        if self.address_line_1:
+            lines.append(self.address_line_1)
+        if self.address_apt_line:
+            lines.append(self.address_apt_line)
+        if self.address_final_line:
+            lines.append(self.address_final_line)
+        return "\n".join(lines)
+
+
+def _to_file_url(path: Path) -> str:
+    return unohelper.systemPathToFileUrl(str(path.resolve()))
+
+
+def _connect_to_office():
+    local_ctx = uno.getComponentContext()
+    resolver = local_ctx.ServiceManager.createInstanceWithContext(
+        "com.sun.star.bridge.UnoUrlResolver", local_ctx
+    )
+    context = resolver.resolve(
+        "uno:socket,host=localhost,port=2002;urp;StarOffice.ComponentContext"
+    )
+    return context
+
+
+def _load_component(component_context, path: Path):
+    desktop = component_context.ServiceManager.createInstanceWithContext(
+        "com.sun.star.frame.Desktop", component_context
+    )
+    properties = (
+        PropertyValue("Hidden", 0, True, 0),
+    )
+    return desktop.loadComponentFromURL(_to_file_url(path), "_blank", 0, properties)
+
+
+def _normalize_family_info(raw: str, family_name: str) -> str:
+    value = raw.strip()
+    if value.lower() == "family":
+        value = "Family"
+    elif "(" in value and ")" in value:
+        match = re.search(r"\(([^)]*)\)", value)
+        if match:
+            value = match.group(1).strip()
+    value = re.sub(r"[^\w\s]", "", value).strip()
+    if not value:
+        value = "Family" if family_name else ""
+    return value
+
+
+def _parse_address_parts(column_c: str) -> tuple[str, str, str]:
+    segments = [segment.strip() for segment in column_c.split(",")]
+    address_line_1 = segments[0] if segments else ""
+    middle = segments[1] if len(segments) > 1 else ""
+    remainder = ",".join(segments[2:]).strip() if len(segments) > 2 else ""
+
+    address_apt_line = ""
+    address_final_line = remainder
+
+    if middle:
+        if "apt" in middle.lower():
+            address_apt_line = middle
+        else:
+            address_final_line = " ".join(filter(None, [middle, remainder])).strip()
+    return address_line_1, address_apt_line, address_final_line
+
+
+def extract_entries(calc_document) -> List[AddressEntry]:
+    sheet = calc_document.Sheets.getByIndex(0)
+    entries: List[AddressEntry] = []
+    empty_rows = 0
+
+    max_rows = sheet.Rows.getCount()
+    for row in range(max_rows):
+        col_a = sheet.getCellByPosition(0, row).getString().strip()
+        col_b = sheet.getCellByPosition(1, row).getString().strip()
+        col_c = sheet.getCellByPosition(2, row).getString().strip()
+
+        if not col_a and not col_b and not col_c:
+            empty_rows += 1
+            if empty_rows >= 5:
+                break
+            continue
+        empty_rows = 0
+
+        if col_a.upper() != "TRUE":
+            continue
+
+        words = col_b.split()
+        if not words:
+            continue
+        family_name = words[0]
+        family_info_raw = " ".join(words[1:])
+        address_line_1, address_apt_line, address_final_line = _parse_address_parts(col_c)
+
+        family_info = _normalize_family_info(family_info_raw, family_name)
+
+        entries.append(
+            AddressEntry(
+                family_name=family_name,
+                family_info=family_info,
+                address_line_1=address_line_1,
+                address_apt_line=address_apt_line,
+                address_final_line=address_final_line,
+            )
+        )
+    return entries
+
+
+def _table_dimensions(table: XTextTable) -> tuple[int, int]:
+    rows = table.Rows.getCount()
+    cols = table.Columns.getCount()
+    return rows, cols
+
+
+def _cell_name(col_index: int, row_index: int) -> str:
+    return f"{chr(ord('A') + col_index)}{row_index + 1}"
+
+
+def populate_table(writer_document, entries: Sequence[AddressEntry]) -> None:
+    tables = writer_document.getTextTables()
+    table_names = tables.getElementNames()
+    if not table_names:
+        raise RuntimeError("No tables found in the Writer document.")
+
+    table = tables.getByName(table_names[0])
+    rows, cols = _table_dimensions(table)
+
+    col = 0
+    row = 0
+    for entry in entries:
+        if col >= cols:
+            break
+        cell_name = _cell_name(col, row)
+        table.getCellByName(cell_name).setString(entry.formatted_text)
+        row += 1
+        if row >= rows:
+            row = 0
+            col += 1
+
+    writer_document.store()
+
+
+def main() -> None:
+    component_context = _connect_to_office()
+
+    calc_document = _load_component(component_context, CALC_PATH)
+    entries = extract_entries(calc_document)
+    calc_document.close(True)
+
+    writer_document = _load_component(component_context, DOC_PATH)
+    populate_table(writer_document, entries)
+    writer_document.close(True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone LibreOffice UNO script that reads filtered rows from a hard-coded spreadsheet
- format family/address text and populate the first table of a hard-coded Writer document in column-major order

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944863ecccc8322abefe06145b6b75f)