### PR TITLE
Add UNO dependency check and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,15 @@ python main.py --input data/input --output data/output/receipts.xlsx \
 ---
 
 Receipts are written to Excel with totals reconciled; mismatches are flagged with status `REVIEW`.
+
+## 📝 LibreOffice table filler
+
+`libreoffice_table_fill.py` talks to LibreOffice over UNO. The UNO runtime is not
+available from PyPI; install LibreOffice with its Python bindings and run the
+script with that interpreter (e.g., `sudo apt install libreoffice python3-uno`
+on Linux, or the Python executable in `LibreOffice\program\python.exe` on
+Windows). Launch LibreOffice in listening mode first:
+
+```
+soffice --headless --accept="socket,host=localhost,port=2002;urp;"
+```

--- a/libreoffice_table_fill.py
+++ b/libreoffice_table_fill.py
@@ -10,10 +10,19 @@ example:
 """
 from __future__ import annotations
 
+import importlib.util
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Sequence
+
+if importlib.util.find_spec("uno") is None:
+    raise ImportError(
+        "The LibreOffice UNO runtime is missing. Install LibreOffice with the "
+        "Python/UNO bindings (e.g., `sudo apt install libreoffice python3-uno` on "
+        "Linux) and run this script with that Python installation instead of the "
+        "PyPI `uno` package."
+    )
 
 import uno
 import unohelper


### PR DESCRIPTION
## Summary
- add a pre-flight UNO availability check to the LibreOffice table filler script
- document how to run the UNO script with the LibreOffice Python bindings and listening service

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ea93c114832285ca7f92050db3f5)