### PR TITLE
Adjust family header ordering

### DIFF
--- a/libreoffice_table_fill.py
+++ b/libreoffice_table_fill.py
@@ -30,7 +30,10 @@ class AddressEntry:
     @property
     def formatted_text(self) -> str:
         lines: List[str] = []
-        header = f"{self.family_info} {self.family_name}".strip()
+        if self.family_info.lower() == "family" and self.family_name:
+            header = f"{self.family_name} {self.family_info}".strip()
+        else:
+            header = f"{self.family_info} {self.family_name}".strip()
         if header:
             lines.append(header)
         if self.address_line_1:

--- a/tests/test_libreoffice_table_fill.py
+++ b/tests/test_libreoffice_table_fill.py
@@ -1,0 +1,25 @@
+from libreoffice_table_fill import AddressEntry
+
+
+def test_family_header_places_family_at_end():
+    entry = AddressEntry(
+        family_name="Smith",
+        family_info="Family",
+        address_line_1="123 Main St",
+        address_apt_line="",
+        address_final_line="Springfield, XY",
+    )
+
+    assert entry.formatted_text.splitlines()[0] == "Smith Family"
+
+
+def test_non_family_header_keeps_prefix():
+    entry = AddressEntry(
+        family_name="Doe",
+        family_info="John & Jane",
+        address_line_1="456 Oak Ave",
+        address_apt_line="Apt 7",
+        address_final_line="Metropolis, ZZ",
+    )
+
+    assert entry.formatted_text.splitlines()[0] == "John & Jane Doe"


### PR DESCRIPTION
## Summary
- place the default "Family" label after the family name when formatting headers
- keep other address headers with the info preceding the family name
- add unit tests covering the formatted header variations

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694893754d3c83228cfe67568f1824b5)